### PR TITLE
Update CommandLineEngineHost.cs

### DIFF
--- a/src/TextTemplating/Infrastructure/CommandLineEngineHost.cs
+++ b/src/TextTemplating/Infrastructure/CommandLineEngineHost.cs
@@ -77,7 +77,10 @@ namespace TextTemplating.Infrastructure
                 return File.ReadAllText(fileName);
             }
 
-            return File.ReadAllText(Path.Combine(Path.GetDirectoryName(TemplateFilePath), fileName));
+            if(string.IsNullOrWhiteSpace(TemplateFilePath))
+                return File.ReadAllText(Path.Combine(Environment.CurrentDirectory, fileName));
+            else
+                return File.ReadAllText(Path.Combine(Path.GetDirectoryName(TemplateFilePath), fileName));
         }
 
         public string ResolvePath(string path)


### PR DESCRIPTION
Fix error:

Unhandled exception. System.ArgumentNullException: Value cannot be null. (Parame
ter 'path1')
   at System.ArgumentNullException.Throw(String paramName)
   at System.IO.Path.Combine(String path1, String path2)
   at TextTemplating.Infrastructure.CommandLineEngineHost.LoadIncludeFile(String
 fileName) in D:\work\dev\netrel\TextTemplatingNet\src\TextTemplating\Infrastruc
ture\CommandLineEngineHost.cs:line 80
   at TextTemplating.T4.Parsing.Parser.ProcessDirective(String blockContent, Par
seResult result) in D:\work\dev\netrel\TextTemplatingNet\src\TextTemplating\T4\P
arsing\Parser.cs:line 228
   at TextTemplating.T4.Parsing.Parser.Parse(String content) in D:\work\dev\netr
el\TextTemplatingNet\src\TextTemplating\T4\Parsing\Parser.cs:line 69
   at TextTemplating.Infrastructure.Engine.PreprocessT4Template(String content,
String className, String classNamespace) in D:\work\dev\netrel\TextTemplatingNet
\src\TextTemplating\Infrastructure\Engine.cs:line 38
   at TextTemplating.Infrastructure.Engine.ProcessT4Template(String content) in
D:\work\dev\netrel\TextTemplatingNet\src\TextTemplating\Infrastructure\Engine.cs
:line 62
   at TextTemplating.Tools.AppCommands.TransformTemplate(String filePath) in D:\
work\dev\netrel\TextTemplatingNet\src\TextTemplating.Cli\AppCommands.cs:line 120

   at TextTemplating.Tools.AppCommands.ProcessTTFile(String path) in D:\work\dev
\netrel\TextTemplatingNet\src\TextTemplating.Cli\AppCommands.cs:line 143
   at TextTemplating.Tools.Program.ProcessFile(String[] args) in D:\work\dev\net
rel\TextTemplatingNet\src\TextTemplating.Cli\Program.cs:line 74
   at TextTemplating.Tools.Program.Main(String[] args) in D:\work\dev\netrel\Tex
tTemplatingNet\src\TextTemplating.Cli\Program.cs:line 41